### PR TITLE
feat(init): add Oak crew stub and gitignore entries, rename treehouse-list to treehouse-view

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ All treehouse operations happen through Claude workflows:
 | `/th:crew:{name}` | Load a crew member |
 | `/th:workflows:nook-fork` | Create a focused worktree |
 | `/th:workflows:checkpoint` | Save current context |
-| `/th:workflows:treehouse-list` | View all nooks |
+| `/th:workflows:treehouse-view` | View all nooks |
 | `/th:workflows:crew-add` | Create a new crew member |
 | `/th:workflows:huddle` | Multi-agent discussion |
 

--- a/internal/assets/workflows/claude/treehouse-view.md
+++ b/internal/assets/workflows/claude/treehouse-view.md
@@ -1,5 +1,5 @@
 ---
-name: 'treehouse-list'
+name: 'treehouse-view'
 description: 'View workspace lineage tree - displays all workspaces with visual hierarchy, marks current location, and provides options for cleanup operations'
 ---
 
@@ -7,5 +7,5 @@ TREEHOUSE_BASE_WORKSPACE={{TREEHOUSE_BASE_WORKSPACE}}
 
 <workflow-loader>
 1. Use `TREEHOUSE_BASE_WORKSPACE` defined above as `BASE_PATH`
-2. LOAD and EXECUTE the workflow from `{BASE_PATH}/.treehouse/workflows/treehouse-list.md`
+2. LOAD and EXECUTE the workflow from `{BASE_PATH}/.treehouse/workflows/treehouse-view.md`
 </workflow-loader>

--- a/internal/assets/workflows/treehouse-view.md
+++ b/internal/assets/workflows/treehouse-view.md
@@ -1,4 +1,4 @@
-# Treehouse List Workflow
+# Treehouse View Workflow
 
 Display workspace lineage as a visual tree with status icons and action menu.
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -62,17 +62,25 @@ func runInit() int {
 		return 1
 	}
 
-	// 4. Create folder structure
+	// 4. Update .gitignore before creating structure
+	gitignoreUpdated, err := updateGitignore(repoInfo.Root)
+	if err != nil {
+		output.PrintError("INIT_GITIGNORE_FAILED", err.Error())
+		return 1
+	}
+
+	// 5. Create folder structure
 	created, err := createTreehouseStructure(treehousePath)
 	if err != nil {
 		output.PrintError("INIT_CREATE_FAILED", err.Error())
 		return 1
 	}
 
-	// 5. Return success
+	// 6. Return success
 	output.PrintSuccess(map[string]interface{}{
-		"path":    treehousePath,
-		"created": created,
+		"path":             treehousePath,
+		"created":          created,
+		"gitignore_updated": gitignoreUpdated,
 	})
 	return 0
 }
@@ -139,6 +147,14 @@ func createTreehouseStructure(basePath string) ([]string, error) {
 	for _, c := range installedCommands {
 		created = append(created, ".claude/commands/th/workflows/"+c)
 	}
+
+	// Create Oak crew command stub
+	oakCommandPath, err := createOakCommandStub(repoRoot)
+	if err != nil {
+		_ = os.RemoveAll(basePath)
+		return nil, err
+	}
+	created = append(created, oakCommandPath)
 
 	return created, nil
 }
@@ -295,4 +311,92 @@ func installClaudeCommands(destPath string, repoRoot string) ([]string, error) {
 	}
 
 	return installed, nil
+}
+
+// createOakCommandStub creates the Claude command stub for Oak crew member
+func createOakCommandStub(repoRoot string) (string, error) {
+	// Create directory structure
+	commandDir := filepath.Join(repoRoot, ".claude", "commands", "th", "crew")
+	if err := os.MkdirAll(commandDir, 0755); err != nil {
+		return "", err
+	}
+
+	commandMD := `# 🌳 Oak
+
+Treehouse Assistant
+
+Load and activate the Oak agent.
+
+## Activation
+
+` + "```" + `
+/th:workflows:agent-loader oak
+` + "```" + `
+`
+
+	commandPath := filepath.Join(commandDir, "oak.md")
+	if err := os.WriteFile(commandPath, []byte(commandMD), 0644); err != nil {
+		return "", err
+	}
+
+	return ".claude/commands/th/crew/oak.md", nil
+}
+
+// treehouseGitignoreMarker is the marker used to identify the treehouse managed block
+const treehouseGitignoreMarker = "# treehouse managed"
+
+// treehouseGitignoreBlock is the content added to .gitignore
+const treehouseGitignoreBlock = `# treehouse managed
+.treehouse/
+.claude/commands/th
+`
+
+// updateGitignore adds treehouse entries to .gitignore if not already present
+// Returns true if the file was updated, false if entries already existed
+func updateGitignore(repoRoot string) (bool, error) {
+	gitignorePath := filepath.Join(repoRoot, ".gitignore")
+
+	// Check if .gitignore exists
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Create new .gitignore with our block
+			if err := os.WriteFile(gitignorePath, []byte(treehouseGitignoreBlock), 0644); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+		return false, err
+	}
+
+	// Check if treehouse entries already exist
+	if containsTreehouseEntries(string(content)) {
+		return false, nil // Already present, no update needed
+	}
+
+	// Append treehouse block to existing content
+	newContent := string(content)
+	if len(newContent) > 0 && newContent[len(newContent)-1] != '\n' {
+		newContent += "\n"
+	}
+	newContent += "\n" + treehouseGitignoreBlock
+
+	if err := os.WriteFile(gitignorePath, []byte(newContent), 0644); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+// containsTreehouseEntries checks if the gitignore content already has treehouse entries
+func containsTreehouseEntries(content string) bool {
+	// Check for the managed marker or the actual entries
+	if strings.Contains(content, treehouseGitignoreMarker) {
+		return true
+	}
+	// Also check for the individual entries in case added manually
+	if strings.Contains(content, ".treehouse/") && strings.Contains(content, ".claude/commands/th") {
+		return true
+	}
+	return false
 }

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -242,7 +242,7 @@ func TestWorkflowInstallation(t *testing.T) {
 
 	// Verify workflows are installed
 	workflowsPath := filepath.Join(dir, ".treehouse", "workflows")
-	expectedWorkflows := []string{"huddle.md", "nook-fork.md", "treehouse-init.md", "treehouse-list.md"}
+	expectedWorkflows := []string{"huddle.md", "nook-fork.md", "treehouse-init.md", "treehouse-view.md"}
 
 	for _, wf := range expectedWorkflows {
 		wfPath := filepath.Join(workflowsPath, wf)
@@ -269,7 +269,7 @@ func TestClaudeCommandInstallation(t *testing.T) {
 
 	// Verify Claude commands are installed
 	claudePath := filepath.Join(dir, ".claude", "commands", "th", "workflows")
-	expectedCommands := []string{"huddle.md", "nook-fork.md", "treehouse-init.md", "treehouse-list.md"}
+	expectedCommands := []string{"huddle.md", "nook-fork.md", "treehouse-init.md", "treehouse-view.md"}
 
 	for _, cmd := range expectedCommands {
 		cmdPath := filepath.Join(claudePath, cmd)
@@ -291,5 +291,174 @@ func TestClaudeCommandInstallation(t *testing.T) {
 
 	if !bytes.Contains(content, []byte(".treehouse/workflows/nook-fork.md")) {
 		t.Error("nook-fork.md has incorrect workflow path")
+	}
+}
+
+func TestOakCommandStubCreation(t *testing.T) {
+	dir := testutil.SetupGitRepo(t)
+	testutil.ChdirWithCleanup(t, dir)
+
+	// Capture output
+	var buf bytes.Buffer
+	output.SetWriter(&buf)
+	t.Cleanup(func() { output.SetWriter(os.Stdout) })
+
+	// Run init command
+	exitCode := Execute([]string{"init"})
+	if exitCode != 0 {
+		t.Fatalf("init failed with exit code %d", exitCode)
+	}
+
+	// Verify Oak command stub was created
+	oakStubPath := filepath.Join(dir, ".claude", "commands", "th", "crew", "oak.md")
+	if _, err := os.Stat(oakStubPath); os.IsNotExist(err) {
+		t.Error("Oak command stub was not created at .claude/commands/th/crew/oak.md")
+	}
+
+	// Verify content has agent-loader reference
+	content, err := os.ReadFile(oakStubPath)
+	if err != nil {
+		t.Fatalf("failed to read oak.md: %v", err)
+	}
+
+	if !bytes.Contains(content, []byte("agent-loader oak")) {
+		t.Error("oak.md missing agent-loader reference")
+	}
+
+	if !bytes.Contains(content, []byte("Oak")) {
+		t.Error("oak.md missing Oak title")
+	}
+}
+
+func TestGitignoreCreation(t *testing.T) {
+	dir := testutil.SetupGitRepo(t)
+	testutil.ChdirWithCleanup(t, dir)
+
+	// Capture output
+	var buf bytes.Buffer
+	output.SetWriter(&buf)
+	t.Cleanup(func() { output.SetWriter(os.Stdout) })
+
+	// Run init command
+	exitCode := Execute([]string{"init"})
+	if exitCode != 0 {
+		t.Fatalf("init failed with exit code %d", exitCode)
+	}
+
+	// Verify .gitignore was created with treehouse entries
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+
+	if !bytes.Contains(content, []byte(".treehouse/")) {
+		t.Error(".gitignore missing .treehouse/ entry")
+	}
+
+	if !bytes.Contains(content, []byte(".claude/commands/th")) {
+		t.Error(".gitignore missing .claude/commands/th entry")
+	}
+
+	if !bytes.Contains(content, []byte("# treehouse managed")) {
+		t.Error(".gitignore missing treehouse managed marker")
+	}
+}
+
+func TestGitignoreIdempotent(t *testing.T) {
+	dir := testutil.SetupGitRepo(t)
+	testutil.ChdirWithCleanup(t, dir)
+
+	// Create existing .gitignore with treehouse entries
+	existingContent := `# my project
+node_modules/
+
+# treehouse managed
+.treehouse/
+.claude/commands/th
+`
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
+		t.Fatalf("failed to create .gitignore: %v", err)
+	}
+
+	// Capture output
+	var buf bytes.Buffer
+	output.SetWriter(&buf)
+	t.Cleanup(func() { output.SetWriter(os.Stdout) })
+
+	// Run init command
+	exitCode := Execute([]string{"init"})
+	if exitCode != 0 {
+		t.Fatalf("init failed with exit code %d", exitCode)
+	}
+
+	// Verify .gitignore was not duplicated
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+
+	// Count occurrences of treehouse marker
+	count := bytes.Count(content, []byte("# treehouse managed"))
+	if count != 1 {
+		t.Errorf("expected 1 treehouse managed marker, found %d", count)
+	}
+
+	// Parse response to verify gitignore_updated is false
+	var resp output.Response
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse JSON response: %v", err)
+	}
+
+	if data, ok := resp.Data.(map[string]interface{}); ok {
+		if updated, ok := data["gitignore_updated"].(bool); ok && updated {
+			t.Error("expected gitignore_updated to be false when entries already exist")
+		}
+	}
+}
+
+func TestGitignoreAppendToExisting(t *testing.T) {
+	dir := testutil.SetupGitRepo(t)
+	testutil.ChdirWithCleanup(t, dir)
+
+	// Create existing .gitignore without treehouse entries
+	existingContent := `# my project
+node_modules/
+*.log`
+	gitignorePath := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
+		t.Fatalf("failed to create .gitignore: %v", err)
+	}
+
+	// Capture output
+	var buf bytes.Buffer
+	output.SetWriter(&buf)
+	t.Cleanup(func() { output.SetWriter(os.Stdout) })
+
+	// Run init command
+	exitCode := Execute([]string{"init"})
+	if exitCode != 0 {
+		t.Fatalf("init failed with exit code %d", exitCode)
+	}
+
+	// Verify .gitignore was appended
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("failed to read .gitignore: %v", err)
+	}
+
+	// Check existing content is preserved
+	if !bytes.Contains(content, []byte("node_modules/")) {
+		t.Error("existing .gitignore content was lost")
+	}
+
+	// Check treehouse entries were added
+	if !bytes.Contains(content, []byte(".treehouse/")) {
+		t.Error(".gitignore missing .treehouse/ entry after append")
+	}
+
+	if !bytes.Contains(content, []byte(".claude/commands/th")) {
+		t.Error(".gitignore missing .claude/commands/th entry after append")
 	}
 }

--- a/workflows/claude/treehouse-view.md
+++ b/workflows/claude/treehouse-view.md
@@ -1,10 +1,10 @@
 ---
-name: 'treehouse-list'
+name: 'treehouse-view'
 description: 'View workspace lineage tree - displays all workspaces with visual hierarchy, marks current location, and provides options for cleanup operations'
 ---
 
 <workflow-loader>
 1. Get `TREEHOUSE_BASE_WORKSPACE` from `env` - this is the base treehouse installation path
 2. If set, use that as `BASE_PATH`. If not set, use current working directory as `BASE_PATH`
-3. LOAD and EXECUTE the workflow from `{BASE_PATH}/.treehouse/workflows/treehouse-list.md`
+3. LOAD and EXECUTE the workflow from `{BASE_PATH}/.treehouse/workflows/treehouse-view.md`
 </workflow-loader>

--- a/workflows/treehouse-view.md
+++ b/workflows/treehouse-view.md
@@ -1,4 +1,4 @@
-# Treehouse List Workflow
+# Treehouse View Workflow
 
 Display workspace lineage as a visual tree with status icons and action menu.
 


### PR DESCRIPTION
## Summary

- **Issue #48**: Add Oak crew command stub on `th init` - creates `.claude/commands/th/crew/oak.md` so Oak is immediately invocable via `/th:crew:oak`
- **Issue #49**: Rename `treehouse-list` workflow to `treehouse-view` - better reflects its interactive viewer nature (⚠️ BREAKING: `/th:workflows:treehouse-list` → `/th:workflows:treehouse-view`)
- **Issue #50**: Add `.gitignore` entries on `th init` - automatically adds `.treehouse/` and `.claude/commands/th` to prevent accidental commits

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests added for Oak stub creation (`TestOakCommandStubCreation`)
- [x] New tests added for gitignore management (`TestGitignoreCreation`, `TestGitignoreIdempotent`, `TestGitignoreAppendToExisting`)
- [x] Build succeeds (`go build -o th ./cmd/th`)
- [ ] Manual test: fresh `th init` creates Oak stub and gitignore entries
- [ ] Manual test: `/th:workflows:treehouse-view` works
- [ ] Manual test: `/th:crew:oak` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)